### PR TITLE
Active tab now reloads when autoNewTab is disabled. (Fixes #7)

### DIFF
--- a/js/eventPage.js
+++ b/js/eventPage.js
@@ -67,7 +67,7 @@ function discardAllTabs(autoNewTab) {
     }
 
     for (var i = 0; i < tabs.length; ++i) {
-      requestTabSuspension(tabs[i]);
+      requestTabSuspension(autoNewTab, tabs[i]);
     }
 
     // highlightNewTabs();
@@ -75,7 +75,7 @@ function discardAllTabs(autoNewTab) {
 }
 
 // request tab suspension
-function requestTabSuspension(tab) {
+function requestTabSuspension(autoNewTab, tab) {
   if (tab === undefined) {
     return;
   }
@@ -86,6 +86,10 @@ function requestTabSuspension(tab) {
   }
   
   if (isDiscarded(tab) || isSpecialTab(tab)) {
+    return;
+  }
+  
+  if (isActiveTab(tab) && !autoNewTab) {
     return;
   }
   
@@ -135,3 +139,6 @@ function isNewTab(tab) {
   return tab.url === 'chrome://newtab/';
 }
 
+function isActiveTab(tab) {
+  return tab.active;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Sloth",
   "short_name": "Sloth",
   "description": "Automatically discards all tabs at startup, before they load, reducing memory footprint and unnecessary bandwidth usage.",
-  "version": "0.3",
+  "version": "0.4",
   "permissions": [
     "tabs"
   ],


### PR DESCRIPTION
This fix adds a check for whether tabs are active and autoNewTab is disabled during the discarding process.