### PR TITLE
Fix manifest v3 error by removing chrome_style

### DIFF
--- a/html/options.html
+++ b/html/options.html
@@ -2,7 +2,7 @@
 <html>
 <head><title>Sloth Options</title></head>
 <style>
-    body: { padding: 1em; }
+    body { padding: 1em; }
 </style>
 <body>
 

--- a/manifest.json
+++ b/manifest.json
@@ -28,7 +28,6 @@
   "manifest_version": 3,
   "minimum_chrome_version": "88",
   "options_ui": {
-    "page": "html/options.html",
-    "chrome_style": true
+    "page": "html/options.html"
   }
 }


### PR DESCRIPTION
The `chrome_style` option in `options_ui` is not supported in manifest version 3. This commit removes the option to fix the extension loading error.

Additionally, I corrected a minor CSS syntax error in `options.html`.